### PR TITLE
Allow Pluto.jl

### DIFF
--- a/src/Bio3DView.jl
+++ b/src/Bio3DView.jl
@@ -24,6 +24,8 @@ end
 
 isijulia() = isdefined(Main, :IJulia) && Main.IJulia.inited
 
+ispluto() = isdefined(Main, :PlutoRunner)
+
 path_lib = normpath(@__DIR__, "..", "js")
 path_3dmol = joinpath(path_lib, "3Dmol-nojquery-min.js")
 path_jquery = joinpath(path_lib, "jquery-3.3.1.min.js")
@@ -333,7 +335,7 @@ function view(tag_str::AbstractString,
         return "<html>\n<meta charset=\"UTF-8\">\n<head></head>\n<body>" *
                 "$ijulia_html</body></html>\n"
     end
-    if isijulia()
+    if isijulia()  || ispluto()
         return HTML(ijulia_html)
     else
         if !isdefined(Main, :Blink)


### PR DESCRIPTION
 This allows `Bio3DView` to be used in [Pluto.jl](https://github.com/fonsp/Pluto.jl) without explicitly using `HTML`. 

![image](https://user-images.githubusercontent.com/2822757/88347685-a2746600-cd4b-11ea-88cb-492a295a0eb7.png)
