### PR TITLE
Add Line and Cylinder objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bio3DView"
 uuid = "99c8bb3a-9d13-5280-9740-b4880ed9c598"
 authors = ["Joe Greener <jgreener@hotmail.co.uk>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"

--- a/src/Bio3DView.jl
+++ b/src/Bio3DView.jl
@@ -8,6 +8,9 @@ export
     Box,
     Axes,
     CameraAngle,
+    NoCap,
+    FlatCap,
+    RoundCap,
     viewfile,
     viewstring,
     viewstruc,
@@ -125,6 +128,18 @@ function Line(
 )
     return Line(start, stop, color, opacity, wireframe, dashed)
 end
+
+"""
+    CapStyle
+
+An primitive enum type for the three cap style options:
+ - `NoCap`
+ - `FlatCap`
+ - `RoundCap`
+"""
+CapStyle
+
+@enum CapStyle NoCap FlatCap RoundCap
 
 """
     Box(center, dimensions)

--- a/src/Bio3DView.jl
+++ b/src/Bio3DView.jl
@@ -5,6 +5,7 @@ export
     Surface,
     IsoSurface,
     Line,
+    Cylinder,
     Box,
     Axes,
     CameraAngle,
@@ -142,6 +143,50 @@ CapStyle
 @enum CapStyle NoCap FlatCap RoundCap
 
 """
+    Cylinder(start, stop; kwargs...)
+
+Data and styling for a cylinder visualisation.
+Arguments are the 3D coordinate vectors for the beginning and end of the cylinder.
+Optional keyword arguments are `color`, `opacity`, `wireframe`, `radius`, `startcap`,
+`stopcap` and `dashed`. `startcap` and `stopcap` must be a [`CapStyle`](@ref)
+"""
+struct Cylinder
+    start::Vector{Float64}
+    stop::Vector{Float64}
+    color::String
+    opacity::Float64
+    wireframe::Bool
+    radius::Float64
+    startcap::CapStyle
+    stopcap::CapStyle
+    dashed::Bool
+end
+
+function Cylinder(
+    start,
+    stop;
+    color::AbstractString="black",
+    opacity::Float64=1.0,
+    wireframe::Bool=true,
+    radius::Float64=1.0,
+    startcap::CapStyle=NoCap,
+    stopcap::CapStyle=NoCap,
+    dashed::Bool=false,
+)
+    return Cylinder(
+        start,
+        stop,
+        color,
+        opacity,
+        wireframe,
+        radius,
+        startcap,
+        stopcap,
+        dashed,
+    )
+end
+
+"""
     Box(center, dimensions)
 
 Data and styling for a box visualisation.
@@ -275,6 +320,20 @@ function linestring(line::Line)
         "dashed:$(line.dashed)});\n"
 end
 
+function cylinderstring(cyl::Cylinder)
+    return "viewer.addCylinder({" *
+        "start:{x:$(cyl.start[1]),y:$(cyl.start[2]),z:$(cyl.start[3])}, " *
+        "end:{x:$(cyl.stop[1]),y:$(cyl.stop[2]),z:$(cyl.stop[3])}, " *
+        "color:'$(cyl.color)', " *
+        "alpha:$(cyl.opacity), " *
+        "wireframe:$(cyl.wireframe), " *
+        "wireframe:$(cyl.wireframe), " *
+        "radius:$(cyl.radius), " *
+        "fromCap:$(Int(cyl.startcap)), " *
+        "toCap:$(Int(cyl.stopcap)), " *
+        "dashed:$(cyl.dashed)});\n"
+end
+
 # Get the script to add a box from a Box object
 function boxstring(box::Box)
     return "viewer.addBox({" *
@@ -336,6 +395,7 @@ function view(tag_str::AbstractString,
                 surface::Union{Surface, Nothing}=nothing,
                 isosurface::Union{IsoSurface, Nothing}=nothing,
                 lines::Union{Line, Vector{Line}, Nothing}=nothing,
+                cylinders::Union{Cylinder, Vector{Cylinder}, Nothing}=nothing,
                 box::Union{Box, Nothing}=nothing,
                 vtkcell::Union{AbstractString, Nothing}=nothing,
                 axes::Union{Axes, Nothing}=nothing,
@@ -371,6 +431,13 @@ function view(tag_str::AbstractString,
     end
     if lines != nothing
         script_str *= mapreduce(linestring, *, lines isa Line ? [lines] : lines)
+    end
+    if cylinders != nothing
+        script_str *= mapreduce(
+            cylinderstring,
+            *,
+            cylinders isa Cylinder ? [cylinders] : cylinders,
+        )
     end
     if box != nothing
         script_str *= boxstring(box)

--- a/src/Bio3DView.jl
+++ b/src/Bio3DView.jl
@@ -168,7 +168,7 @@ function Cylinder(
     color::AbstractString="black",
     opacity::Float64=1.0,
     wireframe::Bool=true,
-    radius::Float64=1.0,
+    radius::Float64=0.1,
     startcap::CapStyle=NoCap,
     stopcap::CapStyle=NoCap,
     dashed::Bool=false,

--- a/src/Bio3DView.jl
+++ b/src/Bio3DView.jl
@@ -253,7 +253,8 @@ Arguments are the filepath and the format ("pdb", "sdf", "xyz" or "mol2").
 If not provided, the format is guessed from the file extension, e.g.
 "myfile.xyz" is treated as being in the xyz format.
 Optional keyword arguments are `style`, `surface`, `isosurface`, `box`,
-`vtkcell`, `axes`, `cameraangle`, `height`, `width`, `html` and `debug`.
+`lines`, `cylinders`, `vtkcell`, `axes`, `cameraangle`, `height`, `width`, `html` and
+`debug`.
 """
 function viewfile(f::AbstractString,
                 format::AbstractString=lowercase(split(f, ".")[end]);
@@ -272,8 +273,8 @@ View a molecular structure contained in a string.
 Displays in a popup window, or in the output cell for an IJulia notebook.
 Arguments are the molecule string and the format ("pdb", "sdf", "xyz" or
 "mol2").
-Optional keyword arguments are `style`, `surface`, `isosurface`, `box`,
-`vtkcell`, `axes`, `cameraangle`, `height`, `width`, `html` and `debug`.
+Optional keyword arguments are `style`, `surface`, `isosurface`, `box`, `lines`,
+`cylinders`, `vtkcell`, `axes`, `cameraangle`, `height`, `width`, `html` and `debug`.
 """
 function viewstring(s::AbstractString,
                 format::AbstractString;
@@ -289,8 +290,8 @@ View a structure from the Protein Data Bank (PDB).
 Displays in a popup window, or in the output cell for an IJulia notebook.
 Argument is the four letter PDB ID, e.g. "1AKE".
 Requires an internet connection to work.
-Optional keyword arguments are `style`, `surface`, `isosurface`, `box`,
-`vtkcell`, `axes`, `cameraangle`, `height`, `width`, `html` and `debug`.
+Optional keyword arguments are `style`, `surface`, `isosurface`, `box`, `lines`,
+`cylinders`, `vtkcell`, `axes`, `cameraangle`, `height`, `width`, `html` and `debug`.
 """
 function viewpdb(p::AbstractString;
                 style::Style=defaultstyle("pdb"),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ style = Style("sphere", Dict("colorscheme"=> "greenCarbon"))
 surface = Surface(Dict("colorscheme"=> "greenCarbon"))
 isosurface = IsoSurface(testfile("benzene.cube"), 0.01)
 box = Box([0.0, 0.0, 0.0], [6.0, 6.0, 6.0])
+lines = [Line([0.0, 1.0, 2.0], [6.0, 7.0, 7.0]), Line([-3.0, -2.0, -1.0], [3.0, 4.0, 5.0])]
 axes = Axes(5, 0.3)
 cameraangle = CameraAngle(0, 0, 0, 0, 0, 0, 0, 1)
 
@@ -32,6 +33,9 @@ viewstruc(struc['A'], surface=surface, html=true)
 
 viewfile(testfile("benzene.sdf"), "sdf", box=box, html=true)
 viewfile(testfile("benzene.sdf"), "sdf", isosurface=isosurface, html=true)
+
+viewfile(testfile("benzene.sdf"), "sdf", lines=lines, html=true)
+viewfile(testfile("benzene.sdf"), "sdf", lines=lines[1], html=true)
 
 viewfile(testfile("IRMOF-1.xyz"), "xyz"; style=Style("stick"), html=true)
 isosurface = IsoSurface(testfile("IRMOF-1.cube"), -5.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,11 @@ surface = Surface(Dict("colorscheme"=> "greenCarbon"))
 isosurface = IsoSurface(testfile("benzene.cube"), 0.01)
 box = Box([0.0, 0.0, 0.0], [6.0, 6.0, 6.0])
 lines = [Line([0.0, 1.0, 2.0], [6.0, 7.0, 7.0]), Line([-3.0, -2.0, -1.0], [3.0, 4.0, 5.0])]
+cylinders = [
+    Cylinder([0.0, 1.0, 2.0], [6.0, 7.0, 7.0]),
+    Cylinder([-3.0, -2.0, -1.0], [3.0, 4.0, 5.0]; startcap=RoundCap, stopcap=FlatCap),
+]
+
 axes = Axes(5, 0.3)
 cameraangle = CameraAngle(0, 0, 0, 0, 0, 0, 0, 1)
 
@@ -36,6 +41,8 @@ viewfile(testfile("benzene.sdf"), "sdf", isosurface=isosurface, html=true)
 
 viewfile(testfile("benzene.sdf"), "sdf", lines=lines, html=true)
 viewfile(testfile("benzene.sdf"), "sdf", lines=lines[1], html=true)
+viewfile(testfile("benzene.sdf"), "sdf", cylinders=cylinders, html=true)
+viewfile(testfile("benzene.sdf"), "sdf", cylinders=cylinders[1], html=true)
 
 viewfile(testfile("IRMOF-1.xyz"), "xyz"; style=Style("stick"), html=true)
 isosurface = IsoSurface(testfile("IRMOF-1.cube"), -5.0)


### PR DESCRIPTION
This PR adds `Line` and `Cylinder` objects corresponding to the [`LineSpec`](https://3dmol.csb.pitt.edu/doc/types.html#LineSpec) and [`CylinderSpec`](https://3dmol.csb.pitt.edu/doc/types.html#CylinderSpec) objects in 3dmol.js. These are especially useful for visualizing distances or distance restraints.