### PR TITLE
Include 3Dmol differently for IJulia or Pluto; Closes #8 and #12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Joe Greener <jgreener@hotmail.co.uk>"]
 version = "0.1.2"
 
 [deps]
-Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Joe Greener <jgreener@hotmail.co.uk>"]
 version = "0.1.2"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
@@ -11,8 +12,8 @@ Requires = "1"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 BioStructures = "de9282ab-8554-53be-b2d6-f6c222edabfc"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "BioStructures"]


### PR DESCRIPTION
Hi! This solves the problem indicated in issues #8 and #12. It looks like inlined *JavaScript* can not be deferred, given the strange warnings and errors when *3Dmol* is inlined. As we can not use `src` to a local file with *Pluto*, I inlined the *JavaScript* inside the `src` argument of the `script` tag using `Base64`. That works perfectly as it can be deferred now :) Maybe @fonsp could be interested in this workaround. Cheers

```julia
using Bio3DView

_path(file) = abspath(dirname(pathof(Bio3DView)), "..", "examples", file)

isosurface = IsoSurface(_path("SBMOF-1.cube"), 100.0, wireframe=true,
	color="green") # contours at -5 kJ/mol

viewfile(_path("SBMOF-1.xyz"), "xyz"; isosurface=isosurface, vtkcell=_path("SBMOF-1.vtk"), axes=Axes(5, 0.3), cameraangle=CameraAngle(0, 0, 0, 0, 0, 0, 0, 1))
```

![image](https://user-images.githubusercontent.com/2822757/115461572-dbcdf980-a229-11eb-9533-598d33d2988b.png)
